### PR TITLE
fix: Update receipts page parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,17 +67,20 @@ async function parseDocuments(fields, $) {
   const docs = scrape(
     $,
     {
-      title: 'td:nth-of-type(4)',
+      title: 'td:nth-of-type(3)',
       amount: {
-        sel: 'td:nth-of-type(5) span',
+        sel: 'td:nth-of-type(4) span',
         parse: normalizePrice
       },
       fileurl: {
-        sel: 'td:nth-of-type(1) a',
-        parse: orderId => `${baseUrl}/profile/orders/${orderId}/receipt.pdf`
+        sel: 'td:nth-of-type(5) a',
+        attr: 'href',
+        parse: relativePath => {
+          return `${baseUrl}${relativePath}`
+        }
       },
       date: {
-        sel: 'td:nth-of-type(7)',
+        sel: 'td:nth-of-type(6)',
         parse: normalizeDate
       },
       vendorRef: 'td:nth-of-type(1) a'
@@ -131,7 +134,12 @@ async function generateMissingReceipts(fields, $) {
 }
 
 function normalizePrice(price) {
-  return parseFloat(price.replace('€', '').trim())
+  return parseFloat(
+    price
+      .replace('€', '')
+      .replace(',', '.')
+      .trim()
+  )
 }
 
 function normalizeDate(dateTime) {


### PR DESCRIPTION
The columns of the parsed table have been moved so we need to update
our scraping selectors:
- the title is now in the 3rd column
- the amount is now in the 4th column
- the file url is now directly available in the 5th column
- the date is now in the 6th column

We also update the amount parsing function to replace commas with dots
as is expected by `parseFloat'.