### PR TITLE
fix: Filter out orders without generated invoices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,7 @@ async function parseDocuments(fields, $) {
         sel: 'td:nth-of-type(5) a',
         attr: 'href',
         parse: relativePath => {
-          return `${baseUrl}${relativePath}`
+          return relativePath ? `${baseUrl}${relativePath}` : undefined
         }
       },
       date: {
@@ -88,23 +88,25 @@ async function parseDocuments(fields, $) {
     },
     'tbody tr'
   )
-  return docs.map(doc => ({
-    ...doc,
-    currency: 'EUR',
-    filename: `${utils.formatDate(
-      doc.date
-    )}_${city}-${providerName}_${doc.amount.toFixed(2)}EUR${
-      doc.vendorRef ? '_' + doc.vendorRef : ''
-    }.pdf`,
-    vendor: VENDOR,
-    metadata: {
-      [VENDOR]: {
-        provider: name,
-        city,
-        summary: doc.title
+  return docs
+    .filter(({ fileurl }) => !!fileurl)
+    .map(doc => ({
+      ...doc,
+      currency: 'EUR',
+      filename: `${utils.formatDate(
+        doc.date
+      )}_${city}-${providerName}_${doc.amount.toFixed(2)}EUR${
+        doc.vendorRef ? '_' + doc.vendorRef : ''
+      }.pdf`,
+      vendor: VENDOR,
+      metadata: {
+        [VENDOR]: {
+          provider: name,
+          city,
+          summary: doc.title
+        }
       }
-    }
-  }))
+    }))
 }
 
 async function generateMissingReceipts(fields, $) {


### PR DESCRIPTION
Coopcycle does not generate invoices until explicitly requested by
the user.
They've recently changed their generation modal, asking if a given
address should be used for billing but we don't yet offer our users
this option in the connector configuration so we leave it to the user
to generate the invoices on the provider's website.

This means that some orders won't have a fileurl and should be
filtered out of the `saveFiles` and `saveBills` calls.