### PR TITLE
fix: Invoice date parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,12 +146,14 @@ function normalizePrice(price) {
 }
 
 function normalizeDate(dateTime) {
-  const formattedDate = dateTime.replace(
-    /(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})/,
-    (_, d, M, Y, h, m) => {
-      return `${Y}-${M}-${d}T${h}:${m}:00`
-    }
-  )
+  const formattedDate = dateTime
+    .replace(
+      /(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})/,
+      (_, d, M, Y, h, m) => {
+        return `${Y}-${M}-${d}T${h}:${m}:00`
+      }
+    )
+    .slice(0, 19) // Use the lower boundary of the delivery time interval as billing date and time
   log('debug', { formattedDate })
   return new Date(formattedDate)
 }


### PR DESCRIPTION
The invoices list does not include the invoicing date but the delivery
date but we use this date as invoicing date on our hand (for matching
purposes and convenience).

However, Coopcycle recently changed the delivery date to reflect the
delivery time interval during which the delivery actually happened.

We arbitrarily decided to use the beginning of the interval as
invoicing time.