### PR TITLE
chore: Update providers list

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -23,16 +23,52 @@
       "label": "providerName",
       "options": [
         {
+          "name": "Amiens (Beefast)",
+          "value": "11"
+        },
+        {
+          "name": "Barcelona (Mensakas)",
+          "value": "12"
+        },
+        {
           "name": "Berlin (Kolyma2)",
           "value": "1"
+        },
+        {
+          "name": "Bilbao (Botxoriders)",
+          "value": "13"
+        },
+        {
+          "name": "Birmingham (Cooperation Birmingham)",
+          "value": "14"
+        },
+        {
+          "name": "Bordeaux (Les Coursiers Bordelais)",
+          "value": "15"
+        },
+        {
+          "name": "Clermont-Ferrand (CYCLOME)",
+          "value": "16"
+        },
+        {
+          "name": "Dijon (A2ROO)",
+          "value": "17"
         },
         {
           "name": "Grenoble (S!cklo)",
           "value": "2"
         },
         {
+          "name": "Guingamp (Breizh Vélo)",
+          "value": "18"
+        },
+        {
           "name": "Liège (RAYON9)",
           "value": "3"
+        },
+        {
+          "name": "Lille / Roubaix (Lille.bike)",
+          "value": "19"
         },
         {
           "name": "Lorient (Feel à Vélo)",
@@ -43,16 +79,44 @@
           "value": "5"
         },
         {
+          "name": "Malmö (Alternativa Kurieren)",
+          "value": "20"
+        },
+        {
+          "name": "Manchester (Chorlton Bike Deliveries)",
+          "value": "21"
+        },
+        {
           "name": "Montpellier (Les Coursiers Montpelliérains)",
           "value": "6"
         },
         {
-          "name": "Nantes (Les Coursiers Nantais)",
+          "name": "Nantes - Les Coursiers Nantais (Les Coursiers Nantais)",
           "value": "7"
+        },
+        {
+          "name": "Nantes - Naofood (Naofood)",
+          "value": "22"
+        },
+        {
+          "name": "Paris (Resto.Paris)",
+          "value": "23"
         },
         {
           "name": "Poitiers (La Poit’ à vélo)",
           "value": "8"
+        },
+        {
+          "name": "Rodez (Biclooo)",
+          "value": "24"
+        },
+        {
+          "name": "Strasbourg (Kooglof)",
+          "value": "25"
+        },
+        {
+          "name": "Vitoria-Gasteiz (Eraman Repartos Gasteiz)",
+          "value": "26"
         },
         {
           "name": "Warsaw (Zentrale)",
@@ -61,6 +125,10 @@
         {
           "name": "York (York Collective)",
           "value": "10"
+        },
+        {
+          "name": "Zaragoza (Zampate)",
+          "value": "27"
         }
       ]
     },

--- a/manifestConfig.json
+++ b/manifestConfig.json
@@ -1,15 +1,51 @@
 [
   {
+    "name": "Amiens (Beefast)",
+    "value": "11"
+  },
+  {
+    "name": "Barcelona (Mensakas)",
+    "value": "12"
+  },
+  {
     "name": "Berlin (Kolyma2)",
     "value": "1"
+  },
+  {
+    "name": "Bilbao (Botxoriders)",
+    "value": "13"
+  },
+  {
+    "name": "Birmingham (Cooperation Birmingham)",
+    "value": "14"
+  },
+  {
+    "name": "Bordeaux (Les Coursiers Bordelais)",
+    "value": "15"
+  },
+  {
+    "name": "Clermont-Ferrand (CYCLOME)",
+    "value": "16"
+  },
+  {
+    "name": "Dijon (A2ROO)",
+    "value": "17"
   },
   {
     "name": "Grenoble (S!cklo)",
     "value": "2"
   },
   {
+    "name": "Guingamp (Breizh Vélo)",
+    "value": "18"
+  },
+  {
     "name": "Liège (RAYON9)",
     "value": "3"
+  },
+  {
+    "name": "Lille / Roubaix (Lille.bike)",
+    "value": "19"
   },
   {
     "name": "Lorient (Feel à Vélo)",
@@ -20,16 +56,44 @@
     "value": "5"
   },
   {
+    "name": "Malmö (Alternativa Kurieren)",
+    "value": "20"
+  },
+  {
+    "name": "Manchester (Chorlton Bike Deliveries)",
+    "value": "21"
+  },
+  {
     "name": "Montpellier (Les Coursiers Montpelliérains)",
     "value": "6"
   },
   {
-    "name": "Nantes (Les Coursiers Nantais)",
+    "name": "Nantes - Les Coursiers Nantais (Les Coursiers Nantais)",
     "value": "7"
+  },
+  {
+    "name": "Nantes - Naofood (Naofood)",
+    "value": "22"
+  },
+  {
+    "name": "Paris (Resto.Paris)",
+    "value": "23"
   },
   {
     "name": "Poitiers (La Poit’ à vélo)",
     "value": "8"
+  },
+  {
+    "name": "Rodez (Biclooo)",
+    "value": "24"
+  },
+  {
+    "name": "Strasbourg (Kooglof)",
+    "value": "25"
+  },
+  {
+    "name": "Vitoria-Gasteiz (Eraman Repartos Gasteiz)",
+    "value": "26"
   },
   {
     "name": "Warsaw (Zentrale)",
@@ -38,5 +102,9 @@
   {
     "name": "York (York Collective)",
     "value": "10"
+  },
+  {
+    "name": "Zaragoza (Zampate)",
+    "value": "27"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "lint": "eslint --fix .",
     "deploy": "git-directory-deploy --directory build/ --branch ${DEPLOY_BRANCH:-build} --repo=${DEPLOY_REPOSITORY:-$npm_package_repository_url}",
     "cozyPublish": "cozy-app-publish --token $REGISTRY_TOKEN --build-commit $(git rev-parse ${DEPLOY_BRANCH:-build})",
-    "travisDeployKey": "./bin/generate_travis_deploy_key"
+    "travisDeployKey": "./bin/generate_travis_deploy_key",
+    "providers": "node ./src/providers.js"
   },
   "dependencies": {
     "cozy-konnector-libs": "4.37.0"

--- a/providers.json
+++ b/providers.json
@@ -1,52 +1,164 @@
 {
   "1": {
+    "label": "Berlin (Kolyma2)",
     "city": "Berlin",
     "name": "Kolyma2",
     "baseUrl": "https://kolyma2.coopcycle.org"
   },
   "2": {
+    "label": "Grenoble (S!cklo)",
     "city": "Grenoble",
     "name": "S!cklo",
     "baseUrl": "https://sicklo.coopcycle.org"
   },
   "3": {
+    "label": "Liège (RAYON9)",
     "city": "Liège",
     "name": "RAYON9",
     "baseUrl": "https://rayon9.coopcycle.org"
   },
   "4": {
+    "label": "Lorient (Feel à Vélo)",
     "city": "Lorient",
     "name": "Feel à Vélo",
     "baseUrl": "https://feelavelo.coopcycle.org"
   },
   "5": {
+    "label": "Madrid (La Pajara)",
     "city": "Madrid",
     "name": "La Pajara",
     "baseUrl": "https://lapajara.coopcycle.org"
   },
   "6": {
+    "label": "Montpellier (Les Coursiers Montpelliérains)",
     "city": "Montpellier",
     "name": "Les Coursiers Montpelliérains",
     "baseUrl": "https://coursiersmontpellier.coopcycle.org"
   },
   "7": {
-    "city": "Nantes",
+    "label": "Nantes - Les Coursiers Nantais (Les Coursiers Nantais)",
+    "city": "Nantes - Les Coursiers Nantais",
     "name": "Les Coursiers Nantais",
     "baseUrl": "https://lescoursiersnantais.coopcycle.org"
   },
   "8": {
+    "label": "Poitiers (La Poit’ à vélo)",
     "city": "Poitiers",
     "name": "La Poit’ à vélo",
     "baseUrl": "https://lapoitavelo.coopcycle.org"
   },
   "9": {
+    "label": "Warsaw (Zentrale)",
     "city": "Warsaw",
     "name": "Zentrale",
     "baseUrl": "https://zentrale.coopcycle.org"
   },
   "10": {
+    "label": "York (York Collective)",
     "city": "York",
     "name": "York Collective",
     "baseUrl": "https://york.coopcycle.org"
+  },
+  "11": {
+    "label": "Amiens (Beefast)",
+    "city": "Amiens",
+    "name": "Beefast",
+    "baseUrl": "https://beefast.coopcycle.org"
+  },
+  "12": {
+    "label": "Barcelona (Mensakas)",
+    "city": "Barcelona",
+    "name": "Mensakas",
+    "baseUrl": "https://mensakas.coopcycle.org"
+  },
+  "13": {
+    "label": "Bilbao (Botxoriders)",
+    "city": "Bilbao",
+    "name": "Botxoriders",
+    "baseUrl": "https://botxoriders.coopcycle.org"
+  },
+  "14": {
+    "label": "Birmingham (Cooperation Birmingham)",
+    "city": "Birmingham",
+    "name": "Cooperation Birmingham",
+    "baseUrl": "https://birmingham.coopcycle.org"
+  },
+  "15": {
+    "label": "Bordeaux (Les Coursiers Bordelais)",
+    "city": "Bordeaux",
+    "name": "Les Coursiers Bordelais",
+    "baseUrl": "https://coursiersbordelais.coopcycle.org"
+  },
+  "16": {
+    "label": "Clermont-Ferrand (CYCLOME)",
+    "city": "Clermont-Ferrand",
+    "name": "CYCLOME",
+    "baseUrl": "https://cyclome.coopcycle.org"
+  },
+  "17": {
+    "label": "Dijon (A2ROO)",
+    "city": "Dijon",
+    "name": "A2ROO",
+    "baseUrl": "https://a2roo.coopcycle.org"
+  },
+  "18": {
+    "label": "Guingamp (Breizh Vélo)",
+    "city": "Guingamp",
+    "name": "Breizh Vélo",
+    "baseUrl": "https://breizhvelo.coopcycle.org"
+  },
+  "19": {
+    "label": "Lille / Roubaix (Lille.bike)",
+    "city": "Lille / Roubaix",
+    "name": "Lille.bike",
+    "baseUrl": "https://lille.coopcycle.org"
+  },
+  "20": {
+    "label": "Malmö (Alternativa Kurieren)",
+    "city": "Malmö",
+    "name": "Alternativa Kurieren",
+    "baseUrl": "https://alternativakuriren.coopcycle.org"
+  },
+  "21": {
+    "label": "Manchester (Chorlton Bike Deliveries)",
+    "city": "Manchester",
+    "name": "Chorlton Bike Deliveries",
+    "baseUrl": "https://chorlton-bike-deliveries.coopcycle.org"
+  },
+  "22": {
+    "label": "Nantes - Naofood (Naofood)",
+    "city": "Nantes - Naofood",
+    "name": "Naofood",
+    "baseUrl": "https://naofood.coopcycle.org"
+  },
+  "23": {
+    "label": "Paris (Resto.Paris)",
+    "city": "Paris",
+    "name": "Resto.Paris",
+    "baseUrl": "https://resto.paris"
+  },
+  "24": {
+    "label": "Rodez (Biclooo)",
+    "city": "Rodez",
+    "name": "Biclooo",
+    "baseUrl": "https://biclooo.coopcycle.org"
+  },
+  "25": {
+    "label": "Strasbourg (Kooglof)",
+    "city": "Strasbourg",
+    "name": "Kooglof",
+    "baseUrl": "https://kooglof.coopcycle.org"
+  },
+  "26": {
+    "label": "Vitoria-Gasteiz (Eraman Repartos Gasteiz)",
+    "city": "Vitoria-Gasteiz",
+    "name": "Eraman Repartos Gasteiz",
+    "baseUrl": "https://eramangasteiz.coopcycle.org"
+  },
+  "27": {
+    "label": "Zaragoza (Zampate)",
+    "city": "Zaragoza",
+    "name": "Zampate",
+    "baseUrl": "https://zampate.coopcycle.org"
   }
 }


### PR DESCRIPTION
Fixes #18 

When updating providers, we need to keep in mind that existing
accounts will keep the `providerId` that was selected when the user
filled in the connection form.

This means that while we want to keep displaying providers in
alphabetical order, we also need to keep the existing match between
provider and provider id.
The `yarn providers` script is updated to make sure fetching the list
of providers from https://coopcycle.org does not override existing
providers but updates them instead and adds new providers starting
with the next available provider id.